### PR TITLE
スマホで見たときのレイアウト崩れ修正

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -86,3 +86,11 @@ footer a:hover {
     line-height: 1.2;
   }
 }
+
+footer {
+  margin-top: 2rem;
+  padding: 2rem 0;
+  background-color: #ffffff;
+  border-top: 1px solid #ffffff;
+  clear: both;
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -79,8 +79,10 @@ footer a:hover {
     flex: 1;
   }
   h1 {
-    height: 80px;
+    min-height: 80px;
     font-size: 43px;
     font-weight: bold;
+    margin-bottom: 1rem;
+    line-height: 1.2;
   }
 }


### PR DESCRIPTION
スマホで見たときにレイアウトが崩れてしまっていたのを修正しました。

||修正前|修正後|
|--:|:--:|:--:|
|タイトル|<img width="158" alt="スクリーンショット 2025-06-06 20 27 42" src="https://github.com/user-attachments/assets/0ab3d05c-cd6f-4ec0-9f5e-06558596d179" />|<img width="158" alt="スクリーンショット 2025-06-06 21 17 45" src="https://github.com/user-attachments/assets/dcd9cc7c-4e99-4794-8fec-977acfa0544d" />|
|フッター|<img width="160" alt="スクリーンショット 2025-06-06 20 27 51" src="https://github.com/user-attachments/assets/79f7d325-8e9e-4a0d-a9ab-731dd96cadb1" />|<img width="156" alt="スクリーンショット 2025-06-06 21 15 50" src="https://github.com/user-attachments/assets/2b36a0e7-63fd-49e8-b059-9b398310ca7e" />|

