### PR TITLE
Blue Sky Share button 削除

### DIFF
--- a/_includes/sns_share.html
+++ b/_includes/sns_share.html
@@ -1,8 +1,5 @@
 <!-- share -->
 <div style="display: flex; gap: 10px;">
-  <bsky-share-button title="【{{ page.title }}】{{ page.sns_message }}" url="{{ page.permalink | relative_url }}"></bsky-share-button>
-  <script src="https://unpkg.com/bsky-share-button@latest/dist/bsky-share-button.umd.js"></script>
-
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-show-count="false" data-text="【{{ page.title }}】{{ page.sns_message }}">tweet</a>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>


### PR DESCRIPTION
Shareボタン押下で作成される文章のURLが正しく作成されないため、一旦ボタンを削除