### PR TITLE
リモートテーマの参照エラー解消のため jekyll-theme-cayman Gemを使用するように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
-  gem "jekyll-remote-theme", "~> 0.4.3"
+  gem "jekyll-theme-cayman", "~> 0.2.0"
 end
 gem "logger"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,15 +75,13 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-remote-theme (0.4.3)
-      addressable (~> 2.0)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
-      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
+    jekyll-theme-cayman (0.2.0)
+      jekyll (> 3.5, < 5.0)
+      jekyll-seo-tag (~> 2.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.12.0)
@@ -110,7 +108,6 @@ GEM
       ffi (~> 1.0)
     rexml (3.4.1)
     rouge (4.5.2)
-    rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass-embedded (1.88.0)
       google-protobuf (~> 4.30)
@@ -161,7 +158,6 @@ PLATFORMS
   riscv64-linux-android
   riscv64-linux-gnu
   riscv64-linux-musl
-  ruby
   x86-linux-gnu
   x86-linux-musl
   x86_64-darwin
@@ -173,7 +169,7 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.4.1)
   jekyll-feed (~> 0.12)
-  jekyll-remote-theme (~> 0.4.3)
+  jekyll-theme-cayman (~> 0.2.0)
   logger
   minima (~> 2.5)
   tzinfo (>= 1, < 3)

--- a/_config.yml
+++ b/_config.yml
@@ -35,10 +35,9 @@ github:
   owner_name: mruby Girls
 
 # Build settings
-remote_theme: pages-themes/cayman@v0.2.0
+theme: jekyll-theme-cayman
 plugins:
   - jekyll-feed
-  - jekyll-remote-theme
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
## 背景
（私の環境だけかもしれないのですが）
開発環境で bundle exec jekyll serve を実行する際、リモートテーマ（remote_theme: pages-themes/cayman@v0.2.0）をダウンロードするプロセスで、OpenSSL::SSLError が発生し、ローカルサーバーを起動できませんでした。

<details><summary>エラーログ</summary>

bundle exec jekyll serve --trace
Configuration file: /Users/ksbmyk/projects/mrubygirls.github.io/_config.yml
      Remote Theme: Using theme pages-themes/cayman
bundler: failed to load command: jekyll (/Users/ksbmyk/.rbenv/versions/3.4.2/bin/jekyll)
/Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/3.4.0/net/protocol.rb:46:in 'OpenSSL::SSL::SSLSocket#connect_nonblock': SSL_connect returned=1 errno=0 peeraddr=20.27.177.114:443 state=error: certificate verify failed (unable to get certificate CRL) (OpenSSL::SSL::SSLError)
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/3.4.0/net/protocol.rb:46:in 'Net::Protocol#ssl_socket_connect'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/3.4.0/net/http.rb:1736:in 'Net::HTTP#connect'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/3.4.0/net/http.rb:1636:in 'Net::HTTP#do_start'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/3.4.0/net/http.rb:1625:in 'Net::HTTP#start'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/3.4.0/net/http.rb:1064:in 'Net::HTTP.start'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme/downloader.rb:42:in 'Jekyll::RemoteTheme::Downloader#download'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme/downloader.rb:24:in 'Jekyll::RemoteTheme::Downloader#run'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme/munger.rb:24:in 'Jekyll::RemoteTheme::Munger#munge!'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme.rb:27:in 'Jekyll::RemoteTheme.init'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme.rb:33:in 'block in <top (required)>'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/hooks.rb:103:in 'block in Jekyll::Hooks.trigger'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/hooks.rb:102:in 'Array#each'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/hooks.rb:102:in 'Jekyll::Hooks.trigger'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/site.rb:119:in 'Jekyll::Site#reset'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/site.rb:35:in 'Jekyll::Site#initialize'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/commands/build.rb:30:in 'Class#new'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/commands/build.rb:30:in 'Jekyll::Commands::Build.process'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:91:in 'block in Jekyll::Command.process_with_graceful_fail'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:91:in 'Array#each'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:91:in 'Jekyll::Command.process_with_graceful_fail'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/lib/jekyll/commands/serve.rb:85:in 'block (2 levels) in Jekyll::Commands::Serve.init_with_program'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in 'block in Mercenary::Command#execute'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in 'Array#each'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in 'Mercenary::Command#execute'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in 'Mercenary::Program#go'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in 'Mercenary.program'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/jekyll-4.4.1/exe/jekyll:15:in '<top (required)>'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/bin/jekyll:25:in 'Kernel#load'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/bin/jekyll:25:in '<top (required)>'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli/exec.rb:59:in 'Kernel.load'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli.rb:452:in 'Bundler::CLI#exec'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/exe/bundle:28:in 'block in <top (required)>'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/exe/bundle:20:in '<top (required)>'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/bin/bundle:25:in 'Kernel#load'
	from /Users/ksbmyk/.rbenv/versions/3.4.2/bin/bundle:25:in '<main>'

</details>


### 原因
jekyll-remote-theme プラグインがテーマを取得するために行った外部へのHTTPS接続時に、証明書の失効リスト（CRL）を取得できず（unable to get certificate CRL）、SSL検証に失敗したためです（この問題は、ローカルのネットワーク環境やOpenSSLの設定に依存します）。

### 変更内容
- _config.yml から remote_theme: pages-themes/cayman@v0.2.0 を削除し、theme: jekyll-theme-cayman を追加しました。
- Gemfile に gem "jekyll-theme-cayman", "~> 0.2.0" を追加し、依存関係としてGemを使用するように変更しました。

### 効果
テーマをGemとしてローカルで管理することで、Jekyllが外部へのテーマダウンロード接続を試みなくなり、安定してローカルサーバーが起動するようになりました。