### PR TITLE
イベントトップページのデザイン修正

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
     <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" as="style" type="text/css" crossorigin>
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/event.css' | relative_url }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -59,43 +59,6 @@ footer a:hover {
   }
 }
 
-.event {
-  .event-info {
-    display: flex;
-  }
-  .event-description {
-    flex: 2;
-  }
-  .event-image {
-    flex: 1;
-  }
-  .program {
-    display: flex;
-  }
-  .schedule {
-    flex: 2;
-  }
-  .information {
-    flex: 1;
-  }
-  .plan {
-   }
-  .plan-time {
-    font-weight: bold;
-  }
-  .plan-description {
-    padding-left: 50px;
-   }
-
-  h1 {
-    min-height: 80px;
-    font-size: 43px;
-    font-weight: bold;
-    margin-bottom: 1rem;
-    line-height: 1.2;
-  }
-}
-
 footer {
   margin-top: 2rem;
   padding: 2rem 0;

--- a/assets/css/event.css
+++ b/assets/css/event.css
@@ -1,0 +1,137 @@
+/* 各イベントページ */
+.event {
+  .event-info {
+    display: flex;
+  }
+  .event-description {
+    flex: 2;
+  }
+  .event-image {
+    flex: 1;
+  }
+  .program {
+    display: flex;
+  }
+  .schedule {
+    flex: 2;
+  }
+  .information {
+    flex: 1;
+  }
+  .plan {
+   }
+  .plan-time {
+    font-weight: bold;
+  }
+  .plan-description {
+    padding-left: 50px;
+   }
+
+  h1 {
+    min-height: 80px;
+    font-size: 43px;
+    font-weight: bold;
+    margin-bottom: 1rem;
+    line-height: 1.2;
+  }
+}
+
+/* Eventsページ */
+.events-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr); /* 基本は3列 */
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+/* 画面幅が小さいときは2列 */
+@media (max-width: 960px) {
+  .events-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* スマホでは1列 */
+@media (max-width: 640px) {
+  .events-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* カード全体の見た目は前と同じ */
+.event-card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.event-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+}
+
+.event-card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  display: block;
+}
+
+.event-card-content {
+  padding: 1rem 1.2rem;
+}
+
+.event-card h3 {
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem;
+  color: #b72d34;
+  font-weight: bold;
+}
+
+.event-date {
+  font-size: 0.9rem;
+  color: #777;
+  margin-bottom: 0.5rem;
+}
+
+.event-desc {
+  font-size: 0.95rem;
+  color: #555;
+  line-height: 1.5;
+  margin-bottom: 0.75rem;
+}
+
+.event-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.event-tag {
+  background: #f8f9fa;
+  border: 1px solid #ddd;
+  border-radius: 9999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.event-link {
+  display: inline-block;
+  margin-top: 0.8rem;
+  color: #e84c7a;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid #e84c7a;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.event-link:hover {
+  background: #e84c7a;
+  color: #fff;
+}

--- a/events/index.markdown
+++ b/events/index.markdown
@@ -3,6 +3,22 @@ layout: default
 permalink: /events/index
 title: イベント情報
 ---
-イベント情報
+## 近日開催のイベント
 
-* [Matsue 1st](/events/2025-11-08-matsue_1st)
+<div class="events-grid">
+  <div class="event-card">
+    <div class="event-card-content">
+      <h3>Matsue 1st</h3>
+      <div class="event-date">2025年11月8日（土）</div>
+      <p class="event-desc">
+        ATOM Matrixを使ってmrubyを体験します。
+      </p>
+      <div class="event-tags">
+        <span class="event-tag">ATOM Matrix</span>
+      </div>
+      <a href="/events/2025-11-08-matsue_1st" class="event-link">詳細を見る →</a>
+    </div>
+  </div>
+
+  <!-- 他のイベントカードも同様に並べる -->
+</div>


### PR DESCRIPTION
簡易なイベントリンクを、カード形式でイベント情報に変更しました。

カード形式のイベント情報には、以下の項目を掲載しています。
* イベント名(Matsue 1st)
* 開催日(2025年11月8日（土）)
* ワークショップ概要
* ワークショップで使用する内容ラベル(ATOM Matrix)
* イベントページへのリンク

スクリーンショットです。
<img width="1168" height="811" alt="image" src="https://github.com/user-attachments/assets/0f18e129-2d3b-4fd4-bf5d-ed3b377be12e" />
