### PR TITLE
回避方法を変更

### DIFF
--- a/guides/esp32/mac_setup.markdown
+++ b/guides/esp32/mac_setup.markdown
@@ -137,9 +137,8 @@ git submodule update --init --recursive
 cd ../..
 ```
 
-
 * 📝 なぜ --recursive が必要？
-     * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。--recursiveを付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
+  * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。--recursiveを付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
 
 ### 2.2 Rubyとbundlerの確認
 

--- a/guides/esp32/mac_setup.markdown
+++ b/guides/esp32/mac_setup.markdown
@@ -83,9 +83,6 @@ cd ~/esp
 git clone -b v5.4.2 --recursive https://github.com/espressif/esp-idf.git
 ```
 
-**なぜ `--recursive` が必要？**
-ESP-IDFは多くのサブモジュール（別のGitリポジトリ）を含んでいます。`--recursive`を付けないと、これらのサブモジュールがダウンロードされず、ビルド時にエラーになります。
-
 ESP32用ツールのインストール
 
 ```bash

--- a/guides/esp32/mac_setup.markdown
+++ b/guides/esp32/mac_setup.markdown
@@ -129,12 +129,10 @@ git clone --recursive https://github.com/picoruby/R2P2-ESP32.git
 cd R2P2-ESP32
 ```
 
-動作確認済みバージョンに固定
+動作確認済みバージョンに固定、サブモジュールも同じ時点の状態に更新
 ```bash
-cd components/picoruby-esp32
-git checkout 344f189
+git checkout 80ebc33
 git submodule update --init --recursive
-cd ../..
 ```
 
 * 📝 なぜ --recursive が必要？

--- a/guides/esp32/wsl_setup.markdown
+++ b/guides/esp32/wsl_setup.markdown
@@ -118,16 +118,15 @@ git clone --recursive https://github.com/picoruby/R2P2-ESP32.git
 cd R2P2-ESP32
 ```
 
-動作確認済みバージョンに固定
+動作確認済みバージョンに固定、サブモジュールも同じ時点の状態に更新
 ```bash
-cd components/picoruby-esp32
-git checkout 344f189
+git checkout 80ebc33
 git submodule update --init --recursive
-cd ../..
 ```
 
 * 📝 なぜ --recursive が必要？
-     * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。--recursiveを付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
+  * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。--recursiveを付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
+
 
 ### 2.2 初期セットアップとビルド
 


### PR DESCRIPTION
picoruby-esp32のリビジョンを操作するのではなく、R2P2-ESP32のリビジョンを最初から固定した方がトラブルを防げそうとアドバイスいただいたので、R2P2-ESP32を確実に動く `80ebc33` としました