### PR TITLE
add sponsor Pixiv for Matsue 1st

### DIFF
--- a/events/2025-11-08-matsue_1st.markdown
+++ b/events/2025-11-08-matsue_1st.markdown
@@ -106,6 +106,11 @@ mrubyのお話
       </p>
 
       <p>
+        <a href="https://www.pixiv.co.jp/" style="float:right; margin:0 0 0 15px; border:0; "><img src="/images/matsue1st/pixiv.png" alt="ピクシブ株式会社" width="200"></a>
+        <a href="https://www.pixiv.co.jp/">ピクシブ株式会社</a>は「Accelerate creativity. 創作活動を、もっと楽しくする。」という企業理念のもと、クリエイターを支援するさまざまなサービスを提供しています。
+      </p>
+
+      <p>
         <a href="http://ruby-no-kai.org">日本Rubyの会</a>は、Rubyの利用者の支援とRuby(とRubyのライブラリ)開発者の支援を目的とした一般社団法人です。
         現在は、ドキュメントの整備や、イベントへの参加協力等を中心に活動しています。
       </p>


### PR DESCRIPTION
提出頂いたロゴは白だったのですが、背景白なのでPixivさんのサイトからダウンロードした、
青ロゴで掲載しました。

<img width="1181" height="586" alt="image" src="https://github.com/user-attachments/assets/fb5af45a-1cc4-4aa3-ab83-f7e8d422151a" />
