### PR TITLE
「--recursive」の出力修正

### DIFF
--- a/guides/esp32/mac_setup.markdown
+++ b/guides/esp32/mac_setup.markdown
@@ -129,8 +129,8 @@ git clone --recursive https://github.com/picoruby/R2P2-ESP32.git
 cd R2P2-ESP32
 ```
 
-* 📝 なぜ --recursive が必要？
-  * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。--recursiveを付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
+* 📝 なぜ `--recursive` が必要？
+  * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。`--recursive`を付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
 
 ### 2.2 Rubyとbundlerの確認
 

--- a/guides/esp32/wsl_setup.markdown
+++ b/guides/esp32/wsl_setup.markdown
@@ -118,8 +118,8 @@ git clone --recursive https://github.com/picoruby/R2P2-ESP32.git
 cd R2P2-ESP32
 ```
 
-* 📝 なぜ --recursive が必要？
-  * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。--recursiveを付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
+* 📝 なぜ `--recursive` が必要？
+  * R2P2-ESP32はPicoRubyをサブモジュールとして含んでいます。`--recursive`を付けないと、PicoRuby本体がダウンロードされず、ビルドできません。
 
 
 ### 2.2 初期セットアップとビルド


### PR DESCRIPTION
`--` がEN DASH(U+2013)になっていました．

### pull-request前

<img width="781" height="56" alt="image" src="https://github.com/user-attachments/assets/649e587e-9ccf-4062-9f99-05213435d4e1" />

### pull-request後

<img width="781" height="56" alt="image" src="https://github.com/user-attachments/assets/9e66e83f-2496-4cd0-ab10-01f1631f0299" />
