### PR TITLE
picoruby-ws2812 の参照ブランチを main に変更

### DIFF
--- a/guides/esp32/atom_matrix/led.markdown
+++ b/guides/esp32/atom_matrix/led.markdown
@@ -74,50 +74,59 @@ irb>
 ```ruby
 require 'ws2812'
 
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
+led = WS2812.new(pin: 27, num: 25)
 
-led.show_rgb([255, 0, 0])
+led.set_rgb(0, 255, 0, 0)
+led.show
 ```
 
 左上、0番目のLEDが赤になりました
 
-show_hexメソッドを使うと16進でも色を指定できます
+set_hexメソッドを使うと16進でも色を指定できます
 ```ruby
-led.show_hex(0xFF0000)
+led.set_hex(0, 0xFF0000)
+led.show
 ```
 
 
 好きな色に変えてみましょう
 ```
 # RGB値で指定
-led.show_rgb([0, 255, 0])    # 緑
-led.show_rgb([0, 0, 255])    # 青
-led.show_rgb([255, 255, 0])  # 黄色
-led.show_rgb([255, 0, 255])  # マゼンタ
+led.set_rgb(0, 0, 255, 0)    # 緑
+led.show
+led.set_rgb(0, 0, 0, 255)    # 青
+led.show
+led.set_rgb(0, 255, 255, 0)  # 黄色
+led.show
+led.set_rgb(0, 255, 0, 255)  # マゼンタ
+led.show
 
 # または16進数で
-led.show_hex(0x00FF00)  # 緑
-led.show_hex(0x0000FF)  # 青
+led.set_hex(0, 0x00FF00)  # 緑
+led.show
+led.set_hex(0, 0x0000FF)  # 青
+led.show
 ```
 
-複数点灯させます。指定した前から順番に0番目、2番目と解釈されていきます。
+複数点灯させます。第1引数にLEDのインデックスを指定します。
 
 ```
 # RGB値で指定
-led.show_rgb([255, 0, 0], [0, 255, 0], [0, 0, 255])
+led.set_rgb(0, 255, 0, 0)
+led.set_rgb(1, 0, 255, 0)
+led.set_rgb(2, 0, 0, 255)
+led.show
 
 # または16進数で
-led.show_hex(0xFF0000, 0x00FF00, 0x0000FF)
+led.set_hex(0, 0xFF0000)
+led.set_hex(1, 0x00FF00)
+led.set_hex(2, 0x0000FF)
+led.show
 ```
 
-黒を指定することで消灯させることができます。
+clearメソッドで全てのLEDを消灯できます。
 ```
-# RGB値で指定
-led.show_rgb([0, 0, 0], [0, 0, 0], [0, 0, 0])
-
-# または16進数で
-led.show_hex(0x000000, 0x000000, 0x000000)
+led.clear
 ```
 
 ## 4. ファイルを送る
@@ -132,25 +141,14 @@ PCで以下の内容のファイルを作り、 `R2P2-ESP32/storage/home/` の�
 ```ruby
 require 'ws2812'
 
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
-
-# 配列を使って全LEDを制御
-pixels = [ # 全て消灯
-  [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
-  [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
-  [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
-  [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
-  [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
-]
+led = WS2812.new(pin: 27, num: 25)
 
 # 四隅だけ光らせる
-pixels[0] = [255, 0, 0]    # 左上
-pixels[4] = [0, 255, 0]    # 右上
-pixels[20] = [0, 0, 255]   # 左下
-pixels[24] = [255, 255, 0] # 右下
-
-led.show_rgb(*pixels)
+led.set_rgb(0, 255, 0, 0)     # 左上
+led.set_rgb(4, 0, 255, 0)     # 右上
+led.set_rgb(20, 0, 0, 255)    # 左下
+led.set_rgb(24, 255, 255, 0)  # 右下
+led.show
 ```
 
 

--- a/guides/esp32/atom_matrix/led_anim.markdown
+++ b/guides/esp32/atom_matrix/led_anim.markdown
@@ -54,8 +54,7 @@ rake monitor
 ```ruby
 require 'ws2812'
 
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
+led = WS2812.new(pin: 27, num: 25)
 
 # Rubyロゴを1つの位置に表示
 pixels = [
@@ -65,7 +64,8 @@ pixels = [
   0x000000, 0x000000, 0xFF0000, 0x000000, 0x000000,
   0x000000, 0x000000, 0x000000, 0x000000, 0x000000
 ]
-led.show_hex(*pixels)
+pixels.each_with_index { |c, i| led.set_hex(i, c) }
+led.show
 ```
 
 ## 3. 上下に動かす
@@ -74,8 +74,7 @@ led.show_hex(*pixels)
 ```ruby
 require 'ws2812'
 
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
+led = WS2812.new(pin: 27, num: 25)
 
 # Rubyロゴを1つの位置に表示
 up_pixels = [
@@ -95,9 +94,11 @@ down_pixels = [
 ]
 
 3.times do
-  led.show_hex(*up_pixels)
+  up_pixels.each_with_index { |c, i| led.set_hex(i, c) }
+  led.show
   sleep 0.3
-  led.show_hex(*down_pixels)
+  down_pixels.each_with_index { |c, i| led.set_hex(i, c) }
+  led.show
   sleep 0.3
 end
 ```
@@ -108,8 +109,7 @@ end
 require 'ws2812'
 
 button = GPIO.new(39, GPIO::IN)
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
+led = WS2812.new(pin: 27, num: 25)
 
 # Rubyロゴを1つの位置に表示
 up_pixels = [
@@ -130,14 +130,16 @@ down_pixels = [
 
 loop do
   break if button.read == 0
-  led.show_hex(*up_pixels)
+  up_pixels.each_with_index { |c, i| led.set_hex(i, c) }
+  led.show
   sleep 0.3
-  led.show_hex(*down_pixels)
+  down_pixels.each_with_index { |c, i| led.set_hex(i, c) }
+  led.show
   sleep 0.3
 end
 
 # 最後に消灯
-led.show_hex(*Array.new(25, 0x000000))
+led.clear
 ```
 
 ## 4. カスタマイズしよう
@@ -167,8 +169,7 @@ led.show_hex(*Array.new(25, 0x000000))
 require 'ws2812'
 
 button = GPIO.new(39, GPIO::IN)
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
+led = WS2812.new(pin: 27, num: 25)
 
 # Rubyパターン
 ruby = [
@@ -179,31 +180,31 @@ ruby = [
 ]
 
 def draw_pattern(led, pattern, start_row, rows)
-  pixels = Array.new(25, 0x000000)
-  
+  led.fill(0, 0, 0)
+
   rows.times do |y|
     actual_row = start_row + y
     if actual_row >= 0 && actual_row < 5
       5.times do |x|
         index = actual_row * 5 + x
-        pixels[index] = pattern[y][x]
+        led.set_hex(index, pattern[y][x])
       end
     end
   end
-  
-  led.show_hex(*pixels)
+
+  led.show
 end
 
 # Rubyロゴを上下に移動
 loop do
   break if button.read == 0
-  
+
   # 上から下へ
   0.upto(1) do |row|
     draw_pattern(led, ruby, row, 4)
     sleep 0.3
   end
-  
+
   # 下から上へ
   1.downto(0) do |row|
     draw_pattern(led, ruby, row, 4)
@@ -212,5 +213,5 @@ loop do
 end
 
 # 最後に消灯
-led.show_hex(*Array.new(25, 0x000000))
+led.clear
 ```

--- a/guides/esp32/atom_matrix/led_anim.markdown
+++ b/guides/esp32/atom_matrix/led_anim.markdown
@@ -25,7 +25,7 @@ PCで `R2P2-ESP32/components/picoruby-esp32/picoruby/build_config/xtensa-esp.rb`
 ```ruby
   conf.gem core: 'picoruby-pwm'
 
-  conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'release/v0.1.0' # 追加
+  conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'main' # 追加
 
   conf.picoruby(alloc_libc: false)
 ```

--- a/guides/esp32/atom_matrix/tilt_led.markdown
+++ b/guides/esp32/atom_matrix/tilt_led.markdown
@@ -26,7 +26,7 @@ PCで `R2P2-ESP32/components/picoruby-esp32/picoruby/build_config/xtensa-esp.rb`
 ```ruby
   conf.gem core: 'picoruby-pwm'
 
-  conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'release/v0.1.0' # 追加
+  conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'main' # 追加
   conf.gem github: 'bash0C7/picoruby-mpu6886', branch: 'main' # 追加
 
   conf.picoruby(alloc_libc: false)

--- a/guides/esp32/atom_matrix/tilt_led.markdown
+++ b/guides/esp32/atom_matrix/tilt_led.markdown
@@ -123,6 +123,7 @@ mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 50
 # 最初に全消灯
 led.clear
 
@@ -183,6 +184,7 @@ mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 50
 led.clear
 
 loop do

--- a/guides/esp32/atom_matrix/tilt_led.markdown
+++ b/guides/esp32/atom_matrix/tilt_led.markdown
@@ -122,37 +122,36 @@ i2c = I2C.new(
 mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
+led = WS2812.new(pin: 27, num: 25)
 # 最初に全消灯
-led.show_hex(*Array.new(25, 0x000000))
+led.clear
 
 loop do
-  break if button.read == 0 
+  break if button.read == 0
 
   accel = mpu.acceleration
-  
-  pixels = Array.new(25, 0x000000)
+
+  led.fill(0, 0, 0)
   # 中心のみ緑で光らせる
-  pixels[12] = 0x001E00
-  led.show_hex(*pixels)
+  led.set_hex(12, 0x001E00)
+  led.show
 
   if accel[:x] > 0.3
     puts "右に傾いています！ X軸: #{accel[:x]}"
   elsif accel[:x] < -0.3
     puts "左に傾いています！ X軸: #{accel[:x]}"
   end
-  
+
   if accel[:y] > 0.3
     puts "前に傾いています！ Y軸: #{accel[:y]}"
   elsif accel[:y] < -0.3
     puts "後ろに傾いています！ Y軸: #{accel[:y]}"
   end
-  
+
   sleep_ms 200
 end
 
-led.show_hex(*Array.new(25, 0x000000))
+led.clear
 ```
 
 
@@ -183,50 +182,49 @@ i2c = I2C.new(
 mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
-rmt = RMTDriver.new(27)
-led = WS2812.new(rmt)
-led.show_hex(*Array.new(25, 0x000000))
+led = WS2812.new(pin: 27, num: 25)
+led.clear
 
 loop do
-  break if button.read == 0 
+  break if button.read == 0
 
   accel = mpu.acceleration
-  
-  pixels = Array.new(25, 0x000000)
-  pixels[12] = 0x001E00
+
+  led.fill(0, 0, 0)
+  led.set_hex(12, 0x001E00)
 
   if accel[:x] > 0.3
     # 右に傾いた
-    pixels[13] = 0x1E0000
+    led.set_hex(13, 0x1E0000)
     if accel[:x] > 0.6
-      pixels[14] = 0x1E0000
+      led.set_hex(14, 0x1E0000)
     end
   elsif accel[:x] < -0.3
     # 左に傾いた
-    pixels[11] = 0x1E0000
+    led.set_hex(11, 0x1E0000)
     if accel[:x] < -0.6
-      pixels[10] = 0x1E0000
-    end
-  end
-  
-  if accel[:y] > 0.3
-    pixels[17] = 0x00001E
-    if accel[:y] > 0.6
-      pixels[22] = 0x00001E
-    end
-  elsif accel[:y] < -0.3
-    pixels[7] = 0x00001E
-    if accel[:y] < -0.6
-      pixels[2] = 0x00001E
+      led.set_hex(10, 0x1E0000)
     end
   end
 
-  led.show_hex(*pixels)
-  
+  if accel[:y] > 0.3
+    led.set_hex(17, 0x00001E)
+    if accel[:y] > 0.6
+      led.set_hex(22, 0x00001E)
+    end
+  elsif accel[:y] < -0.3
+    led.set_hex(7, 0x00001E)
+    if accel[:y] < -0.6
+      led.set_hex(2, 0x00001E)
+    end
+  end
+
+  led.show
+
   sleep_ms 200
 end
 
-led.show_hex(*Array.new(25, 0x000000))
+led.clear
 ```
 
 シリアルモニターを `Ctr+]` で終了し、 `ESPBAUD=115200 rake flash` で書き込み、 `rake monitor` でシリアルモニタで立ち上げ


### PR DESCRIPTION
## 概要                                                                                                                                                               
- picoruby-ws2812 gem の参照ブランチを release/v0.1.0 から main に変更                                                                                              
- サンプルコードを現在の WS2812 API に合わせて更新

## 背景
ws2812 側にインターフェースの破壊的変更があったため、サンプルコードの書き換えが完了するまでバージョンを固定していた
本PRでサンプルコードを新しいAPIに対応させたため、固定を解除する