### PR TITLE
set brightness to 30 for all sample code

### DIFF
--- a/guides/esp32/atom_matrix/led.markdown
+++ b/guides/esp32/atom_matrix/led.markdown
@@ -75,6 +75,7 @@ irb>
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 30
 
 led.set_rgb(0, 255, 0, 0)
 led.show
@@ -142,6 +143,7 @@ PCで以下の内容のファイルを作り、 `R2P2-ESP32/storage/home/` の�
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 30
 
 # 四隅だけ光らせる
 led.set_rgb(0, 255, 0, 0)     # 左上

--- a/guides/esp32/atom_matrix/led_anim.markdown
+++ b/guides/esp32/atom_matrix/led_anim.markdown
@@ -55,6 +55,7 @@ rake monitor
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 30
 
 # Rubyロゴを1つの位置に表示
 pixels = [
@@ -75,6 +76,7 @@ led.show
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 30
 
 # Rubyロゴを1つの位置に表示
 up_pixels = [
@@ -110,6 +112,7 @@ require 'ws2812'
 
 button = GPIO.new(39, GPIO::IN)
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 30
 
 # Rubyロゴを1つの位置に表示
 up_pixels = [
@@ -170,6 +173,7 @@ require 'ws2812'
 
 button = GPIO.new(39, GPIO::IN)
 led = WS2812.new(pin: 27, num: 25)
+led.brightness = 30
 
 # Rubyパターン
 ruby = [

--- a/guides/esp32/atom_matrix/tilt_led.markdown
+++ b/guides/esp32/atom_matrix/tilt_led.markdown
@@ -123,7 +123,7 @@ mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 50
+led.brightness = 30
 # 最初に全消灯
 led.clear
 
@@ -184,7 +184,7 @@ mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 50
+led.brightness = 30
 led.clear
 
 loop do


### PR DESCRIPTION
Summary

- 全サンプルコードに led.brightness = 30 を設定
- tilt_led.markdown では既存の brightness = 50 を 30 に変更
- led.markdown、led_anim.markdown では未設定だったため新規追加

Background

WS2812のbrightnessのデフォルトは5で、25個のLEDでは暗すぎる。一方、50だと眩しいため、30に統一した。