### PR TITLE
brightnessを20に制限

### DIFF
--- a/guides/esp32/atom_matrix/led.markdown
+++ b/guides/esp32/atom_matrix/led.markdown
@@ -75,7 +75,7 @@ irb>
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 
 led.set_rgb(0, 255, 0, 0)
 led.show
@@ -143,7 +143,7 @@ PCで以下の内容のファイルを作り、 `R2P2-ESP32/storage/home/` の�
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 
 # 四隅だけ光らせる
 led.set_rgb(0, 255, 0, 0)     # 左上

--- a/guides/esp32/atom_matrix/led_anim.markdown
+++ b/guides/esp32/atom_matrix/led_anim.markdown
@@ -55,7 +55,7 @@ rake monitor
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 
 # Rubyロゴを1つの位置に表示
 pixels = [
@@ -76,7 +76,7 @@ led.show
 require 'ws2812'
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 
 # Rubyロゴを1つの位置に表示
 up_pixels = [
@@ -112,7 +112,7 @@ require 'ws2812'
 
 button = GPIO.new(39, GPIO::IN)
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 
 # Rubyロゴを1つの位置に表示
 up_pixels = [
@@ -173,7 +173,7 @@ require 'ws2812'
 
 button = GPIO.new(39, GPIO::IN)
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 
 # Rubyパターン
 ruby = [

--- a/guides/esp32/atom_matrix/tilt_led.markdown
+++ b/guides/esp32/atom_matrix/tilt_led.markdown
@@ -123,7 +123,7 @@ mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 # 最初に全消灯
 led.clear
 
@@ -184,7 +184,7 @@ mpu = MPU6886.new(i2c)
 button = GPIO.new(39, GPIO::IN)
 
 led = WS2812.new(pin: 27, num: 25)
-led.brightness = 30
+led.brightness = 20
 led.clear
 
 loop do


### PR DESCRIPTION
LEDの損傷を防ぐため、メーカー推奨の上限値20に変更しました

> LEDの損傷を防ぐため、RGB LEDの明るさを制限してください。UIFlowでの上限は20です。

https://www.switch-science.com/products/6260?_pos=1&_sid=4002c680c&_ss=r
